### PR TITLE
ACP2E-1189: [Documentation] Add Bundle Product automatic status update rules into Bundle Product documentation

### DIFF
--- a/help/catalog/product-create-bundle.md
+++ b/help/catalog/product-create-bundle.md
@@ -251,6 +251,16 @@ Scroll down and complete the information in the following sections as needed:
 
 {style="table-layout:auto"}
 
+## Bundle product Stock Status
+
+Bundle product Stock Status is automatically changed to **_Out of Stock_** if either:
+- All options are optional and all associated products are _Out of Stock_.
+- Some options are required and all products, which are associated to any required option, are _Out of Stock_.
+
+Bundle Product Stock Status is **_not_** automatically changed to **Out of Stock** if either:
+- All options are optional and at least one associated product is _In Stock_.
+- Some options are required and at least one associated product in each required option is _In Stock_.
+
 ## Things to remember
 
 ![Checkbox](../assets/checkbox.png) Customers can _build their own_ bundle product.


### PR DESCRIPTION
## Purpose of this pull request

_Describe the goal and the type of changes this pull request covers. Tell us what changes you are making and why._

According to changes implemented in scope of [ACP2E-262](https://jira.corp.adobe.com/browse/ACP2E-262) please add following changes in documentation:

Bundle Product Stock Status is automatically changed to "Out of Stock" if either:
- All options are optional and all associated products are out of stock;
- Some options are required and all associated products to a required option are out of stock.

Bundle Product Stock Status is left as "In Stock" if either:
- All options are optional and at least one associated product is in-stock;
- Some options are required and at least one associated product in each required option is in-stock.

Product Owner approve:
https://jira.corp.adobe.com/browse/ACP2E-262?focusedCommentId=30755998&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30755998

## Magento release version

_Which Magento release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

- Magento 2.4.x

## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- No.

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- No.

## Affected documentation pages

_List HTML links for affected pages on <https://docs.magento.com/user-guide/>._

- https://experienceleague.adobe.com/docs/commerce-admin/catalog/products/types/product-create-bundle.html?lang=en