### PR TITLE
Update security-two-factor-authentication.md

### DIFF
--- a/help/systems/security-two-factor-authentication.md
+++ b/help/systems/security-two-factor-authentication.md
@@ -62,7 +62,7 @@ To change how long the one-time password (OTP) is available during sign-in, clea
 
 >[!NOTE]
 >
->In Adobe Commerce 2.4.7 and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. This value must be less than 30 seconds. The system default setting is `29`.<br><br> In version 2.4.6, the OTP window setting determines the number of past and future OTP codes that remain valid. A value of `1` indicates that the current OTP code plus one code in the past and one code in the future remain valid at any given point in time. 
+>In Adobe Commerce 2.4.7 and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. This value must be less than 30 seconds.<br><br> In version 2.4.6, the OTP window setting determines the number of past and future OTP codes that remain valid. A value of `1` indicates that the current OTP code plus one code in the past and one code in the future remain valid at any given point in time. 
 
 ### [!DNL Duo Security]
 

--- a/help/systems/security-two-factor-authentication.md
+++ b/help/systems/security-two-factor-authentication.md
@@ -62,7 +62,7 @@ To change how long the one-time password (OTP) is available during sign-in, clea
 
 >[!NOTE]
 >
->In Adobe Commerce 2.4.7 and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. This value must be less than 30 seconds. The system default setting is `1`.<br><br> In version 2.4.6, the OTP window setting determines the number of past and future OTP codes that remain valid. A value of `1` indicates that the current OTP code plus one code in the past and one code in the future remain valid at any given point in time. 
+>In Adobe Commerce 2.4.7 and later, the OTP window configuration setting controls how long (in seconds) the system accepts an administrator's one-time-password (OTP) after it has expired. This value must be less than 30 seconds. The system default setting is `29`.<br><br> In version 2.4.6, the OTP window setting determines the number of past and future OTP codes that remain valid. A value of `1` indicates that the current OTP code plus one code in the past and one code in the future remain valid at any given point in time. 
 
 ### [!DNL Duo Security]
 


### PR DESCRIPTION
## Purpose of the pull request

Removed the mention of the default setting for the OTP Window setting.

In 2.4.7, it is `1`.  Default was updated to `29` in  in the 2.4.7-p1 security patch to account for the change to using the OTP leeway period ([AC-111937](https://jira.corp.adobe.com/browse/AC-11937).)

Doesn't seem necessary to mention the default because it will display in the Admin interface.

## Affected pages

https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/2fa/security-two-factor-authentication
