### PR TITLE
Update install.md

### DIFF
--- a/help/b2b/install.md
+++ b/help/b2b/install.md
@@ -14,7 +14,7 @@ The Adobe Commerce B2B extension, `magento/extension-b2b` is available for all s
 ## Requirements
 
 - [Adobe Commerce](https://business.adobe.com/products/magento/magento-commerce.html), all supported versions
-- PHP 8.1 / 8.2 / 8.3
+- PHP 8.1 / 8.2 
 - [!DNL Composer]
 
 ## Supported platforms


### PR DESCRIPTION
Its not supported 

composer require-commerce magento/product-enterprise-edition 2.4.7-p1 --no-update -> composer update Problem 1 - magento/module-b2b is locked to version 100.4.1-p1 and an update of this package was not requested. - magento/module-b2b 100.4.1-p1 requires php ~8.1.0||~8.2.0 -> your php version (8.3.8) does not satisfy that requirement.

Ref: ACP2E-3133

## Purpose of the pull request

This pull request (PR) Update documentation

## Affected pages

https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/install
