### PR TITLE
Update adobe-stock.md

### DIFF
--- a/help/content-design/adobe-stock.md
+++ b/help/content-design/adobe-stock.md
@@ -55,7 +55,7 @@ Configuring the Adobe Stock integration for Adobe Commerce is a two-step process
    - Any periods (`.`) must be escaped with two backslashes (`\\`).
    - Add `.*` to the end of the pattern.
 
-   Using the example from the previous default redirect URI, it would be `https://store\\.myshop\\.com/admin_hgkq1l/adobe_ims/oauth/callback/.*`.
+   Using the example from the previous default redirect URI, it would be `https://store\\.myshop\\.com/admin_hgkq1l/adobe_ims/oauth/callback/.*`
 
 1. Click **[!UICONTROL Next]**.
 


### PR DESCRIPTION
Purpose of the pull request

- Removing punctuation from the end of the line that contains a web address, so it doesn't look like the '.' is part of the URL.


Affected pages

- https://experienceleague.adobe.com/en/docs/commerce-admin/content-design/wysiwyg/adobe-stock/adobe-stock



