### PR TITLE
Fix wording on expiration date for quote templates

### DIFF
--- a/help/b2b/quote-templates-overview.md
+++ b/help/b2b/quote-templates-overview.md
@@ -41,9 +41,7 @@ Quote templates can be initiated by the buyer or the seller.
 
   ![Seller initiating a buyer quote from the Quotes grid in the Admin](./assets/quote-template-create-from-grid.png){width="700" zoomable="yes"}
   
-  When the seller creates the quote template, the expiration date ([!UICONTROL Valid until] date field) defaults to 180 days. If the buyer created the template, the expiration date is blank.  The buyer must set the expiration date before sending the template back to the buyer for review.
-
-  When the seller creates the quote template, the expiration date (*[!UICONTROL Valid until]* date field) defaults to 180 days. If the buyer created the template, the expiration date is blank.  The buyer must set the expiration date before sending the template back to the buyer for review.
+  When the seller creates the quote template, the expiration date (*[!UICONTROL Valid until]* date field) defaults to 180 days. If the buyer created the template, the expiration date is blank. The buyer must set the expiration date before sending the template back to the seller for review.
 
 **Step 2: Quote review and negotiation (Review)**
 


### PR DESCRIPTION
Corrected the wording for clarity regarding the expiration date of quote templates created by sellers and buyers.

## Purpose of the pull request

This pull request fixes two issues in the "Sales representative" section of the Quote template workflow:

- Typo fix — Changed "sending the template back to the buyer for review" to "sending the template back to the seller for review". The original wording incorrectly stated the buyer sends the template back to themselves.
- Duplicate paragraph removed — The corrected paragraph was duplicated twice in a row; the duplicate has been removed.


## Affected pages

<!-- It is a best practice to list the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. Including both production and staging/review URLs is most helpful. -->

- https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/templates/quote-templates-overview


<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

-->
