### PR TITLE
Fix incorrect field name: Company Status Change Email Recipient

### DIFF
--- a/help/b2b/install.md
+++ b/help/b2b/install.md
@@ -46,7 +46,7 @@ The Adobe Commerce B2B extension, `magento/extension-b2b` is available for all s
 
 >[!ENDSHADEBOX]
 
-Install the B2B extension (`magento/b2b-extension`) using Composer. The extension is a composer metapackage that includes the collection of modules that enable the B2B capabilities for an Adobe Commerce instance. For a list of included modules, see [B2B Packages](packages.md).
+Install the B2B extension (`magento/extension-b2b`) using Composer. The extension is a composer metapackage that includes the collection of modules that enable the B2B capabilities for an Adobe Commerce instance. For a list of included modules, see [B2B Packages](packages.md).
 
 >[!BEGINTABS]
 
@@ -184,7 +184,7 @@ Prevent possible processing issues or delays by adding the following parameters 
 
 - `--batch-size <value>`— Allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.  If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue.
 
-For information about additional configuration options, see [Specific-configuration](https://experienceleague.adobe.com//en/docs/commerce-operations/configuration-guide/message-queues/manage-message-queues#specific-configuration).
+For information about additional configuration options, see [Specific-configuration](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/message-queues/manage-message-queues#specific-configuration).
 
 ### Start message consumers
 


### PR DESCRIPTION
## Purpose of the pull request

This PR fixes two issues on the [Install the Adobe Commerce B2B extension (https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/install) page.

### 1. Broken link caused by double slash in URL

The link to "Specific-configuration" in the "Configure message consumers" section contains a double slash (`.com//en/`) in the URL. This malformed URL renders on the live page as `https://en/docs/...` — the domain is stripped and the link leads nowhere.

**Before:**
`https://experienceleague.adobe.com//en/docs/commerce-operations/configuration-guide/message-queues/manage-message-queues#specific-configuration`

**After:**
`https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/message-queues/manage-message-queues#specific-configuration`

### 2. Incorrect Composer package name

In the "Installation steps" intro, the package is referenced as `magento/b2b-extension`, but the correct name is `magento/extension-b2b`. This is confirmed by:

- All `composer require` commands on the same page use `magento/extension-b2b`
- The [official B2B Packages reference](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/reference/packages) documents `magento/extension-b2b`

**Before:**
`Install the B2B extension (`magento/b2b-extension`) using Composer.`

**After:**
`Install the B2B extension (`magento/extension-b2b`) using Composer.`

## Affected pages

<!-- It is a best practice to list the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. Including both production and staging/review URLs is most helpful. -->

- https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/install

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

-->
