### PR TITLE
Fix typo in Company Status Change Email Recipient

### DIFF
--- a/help/b2b/email-company-configuration.md
+++ b/help/b2b/email-company-configuration.md
@@ -50,7 +50,7 @@ The [sales representative](account-company-manage.md) that is assigned as the pr
 
 1. Complete the **[!UICONTROL Company Status Change]** section:
 
-   - Set **[!UICONTROL Company Status Change for Email Recipient]** to the [store contact](../getting-started/store-details.md#store-email-addresses) who is to be notified when the status of a company changes.
+   - Set **[!UICONTROL Company Status Change Email Recipient]** to the [store contact](../getting-started/store-details.md#store-email-addresses) who is to be notified when the status of a company changes.
 
    - In the **[!UICONTROL Send Company Status Change Email Copy To]** field, enter the email address of each person who is to receive a copy of the status change notification. Separate multiple email addresses with a comma.
 


### PR DESCRIPTION
## Purpose of the pull request

This PR fixes an incorrect field name on the [Configure company email options](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/companies/email-company-configuration) page.

In step 6 ("Complete the **Company Status Change** section"), the field is referenced as **"Company Status Change for Email Recipient"**, but the actual field name in the Admin UI does not contain the word "for".

The correct field name is **"Company Status Change Email Recipient"**, as documented in the official [Customers > Company Configuration reference](https://experienceleague.adobe.com/en/docs/commerce-admin/config/customers/company-configuration#company-status-change).

## Affected pages

<!-- It is a best practice to list the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. Including both production and staging/review URLs is most helpful. -->

-  <https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/companies/email-company-configuration>



<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

-->
