### PR TITLE
Fix formatting issue in account management documentation

### DIFF
--- a/help/b2b/account-company-manage.md
+++ b/help/b2b/account-company-manage.md
@@ -39,7 +39,7 @@ You can manage accounts individually or in groups.
 
   ![Select action to apply to selected companies](assets/companies-change-settings-edit-selection.png){width="675" zoomable="yes"}
 
-- View or change a group of selected company accounts by using the options available from the [!UICONTROL Actions]** control above the grid.
+- View or change a group of selected company accounts by using the options available from the [!UICONTROL Actions] control above the grid.
 
   ![Select action to apply to selected companies](assets/companies-change-settings-mass-action-selection.png){width="675" zoomable="yes"}
 


### PR DESCRIPTION
## Purpose of the pull request

This PR fixes a markdown rendering bug on the [Manage company accounts](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/companies/account-company-manage) page.

In the "Manage company accounts from the Companies grid" section, the second bullet contains broken bold markdown that renders literally as `Actions**` on the live page (visible stray asterisks).


## Affected pages

<!-- It is a best practice to list the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. Including both production and staging/review URLs is most helpful. -->

-  <https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/companies/account-company-manage>

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

-->
