### PR TITLE
Fix typo in catalog-shared.md

### DIFF
--- a/help/b2b/catalog-shared.md
+++ b/help/b2b/catalog-shared.md
@@ -54,6 +54,6 @@ The [actions controls](../getting-started/admin-actions-control.md) in the upper
 |[!UICONTROL Customer Tax Class]|The tax class that is assigned to the corresponding customer group. This column does not appear in the default grid, but can be added by changing the column layout.|
 |[!UICONTROL Created At]|The date and time the shared catalog was created.|
 |[!UICONTROL Created By]|The first and last name of the store administrator who created the shared catalog.|
-|[!UICONTROL Action]|Lists actions that be applied to selected catalogs. Options: `Set Pricing and Structure` / `Assign Companies` / `General Settings` / `Delete`|
+|[!UICONTROL Action]|Lists actions that can be applied to selected catalogs. Options: `Set Pricing and Structure` / `Assign Companies` / `General Settings` / `Delete`|
 
 {style="table-layout:auto"}


### PR DESCRIPTION
## Purpose of the pull request

This PR fixes a missing word in a field description on the [Shared catalog overview](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) page.

In the "Column descriptions" table, the description for the **Action** field is grammatically broken — the modal verb "can" is missing.

**Before:**
> Lists actions that be applied to selected catalogs.

**After:**
> Lists actions that can be applied to selected catalogs.

## Affected pages

<!-- It is a best practice to list the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. Including both production and staging/review URLs is most helpful. -->

-  <https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared>



<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

-->
