### PR TITLE
Fix wording for default rule status clarification

### DIFF
--- a/help/b2b/account-company-manage.md
+++ b/help/b2b/account-company-manage.md
@@ -39,7 +39,7 @@ You can manage accounts individually or in groups.
 
   ![Select action to apply to selected companies](assets/companies-change-settings-edit-selection.png){width="675" zoomable="yes"}
 
-- View or change a group of selected company accounts by using the options available from the [!UICONTROL Actions]** control above the grid.
+- View or change a group of selected company accounts by using the options available from the [!UICONTROL Actions] control above the grid.
 
   ![Select action to apply to selected companies](assets/companies-change-settings-mass-action-selection.png){width="675" zoomable="yes"}
 

--- a/help/b2b/account-dashboard-approval-rules.md
+++ b/help/b2b/account-dashboard-approval-rules.md
@@ -40,7 +40,7 @@ To create an approval rule, a customer completes the following steps:
 
 1. If needed, changes the rule from **[!UICONTROL Enabled]** to **[!UICONTROL Disabled]**.
 
-   The rule is as enabled as the default, but a customer can create the rule using a disabled setting and then enable it later when they are ready to enforce it.
+   The rule is enabled by default, but a customer can create the rule using a disabled setting and then enable it later when they are ready to enforce it.
 
 1. For **[!UICONTROL Rule name]**, enters a short but descriptive name for the Rule, such as `Orders less than $100`.
 

--- a/help/b2b/catalog-shared.md
+++ b/help/b2b/catalog-shared.md
@@ -54,6 +54,6 @@ The [actions controls](../getting-started/admin-actions-control.md) in the upper
 |[!UICONTROL Customer Tax Class]|The tax class that is assigned to the corresponding customer group. This column does not appear in the default grid, but can be added by changing the column layout.|
 |[!UICONTROL Created At]|The date and time the shared catalog was created.|
 |[!UICONTROL Created By]|The first and last name of the store administrator who created the shared catalog.|
-|[!UICONTROL Action]|Lists actions that be applied to selected catalogs. Options: `Set Pricing and Structure` / `Assign Companies` / `General Settings` / `Delete`|
+|[!UICONTROL Action]|Lists actions that can be applied to selected catalogs. Options: `Set Pricing and Structure` / `Assign Companies` / `General Settings` / `Delete`|
 
 {style="table-layout:auto"}

--- a/help/b2b/credit-company.md
+++ b/help/b2b/credit-company.md
@@ -161,7 +161,7 @@ When managing company credit, implement robust security measures to protect sens
 
 ## Best practices
 
-* * **Credit Policy Management**—When managing company credit, establish clear policies for setting credit limits based on customer payment history and business relationships. Regularly review outstanding balances and payment patterns to assess risk, and always document changes to credit settings with detailed reasons for audit purposes.
+* **Credit Policy Management**—When managing company credit, establish clear policies for setting credit limits based on customer payment history and business relationships. Regularly review outstanding balances and payment patterns to assess risk, and always document changes to credit settings with detailed reasons for audit purposes.
 
 Process payments promptly to maintain accurate balances, and ensure credit currency settings align with each company's primary business operations.
 

--- a/help/b2b/email-company-configuration.md
+++ b/help/b2b/email-company-configuration.md
@@ -50,7 +50,7 @@ The [sales representative](account-company-manage.md) that is assigned as the pr
 
 1. Complete the **[!UICONTROL Company Status Change]** section:
 
-   - Set **[!UICONTROL Company Status Change for Email Recipient]** to the [store contact](../getting-started/store-details.md#store-email-addresses) who is to be notified when the status of a company changes.
+   - Set **[!UICONTROL Company Status Change Email Recipient]** to the [store contact](../getting-started/store-details.md#store-email-addresses) who is to be notified when the status of a company changes.
 
    - In the **[!UICONTROL Send Company Status Change Email Copy To]** field, enter the email address of each person who is to receive a copy of the status change notification. Separate multiple email addresses with a comma.
 

--- a/help/b2b/install.md
+++ b/help/b2b/install.md
@@ -46,7 +46,7 @@ The Adobe Commerce B2B extension, `magento/extension-b2b` is available for all s
 
 >[!ENDSHADEBOX]
 
-Install the B2B extension (`magento/b2b-extension`) using Composer. The extension is a composer metapackage that includes the collection of modules that enable the B2B capabilities for an Adobe Commerce instance. For a list of included modules, see [B2B Packages](packages.md).
+Install the B2B extension (`magento/extension-b2b`) using Composer. The extension is a composer metapackage that includes the collection of modules that enable the B2B capabilities for an Adobe Commerce instance. For a list of included modules, see [B2B Packages](packages.md).
 
 >[!BEGINTABS]
 
@@ -184,7 +184,7 @@ Prevent possible processing issues or delays by adding the following parameters 
 
 - `--batch-size <value>`— Allows you to limit the system resources consumed by the consumers (CPU, memory). Using smaller batches reduces resource usage and, thus, leads to slower processing.  If specified, messages in a queue are consumed in batches of `<value>` each. This option is applicable for the batch consumer only. If `--batch-size` is not defined, the batch consumer receives all available messages in a queue.
 
-For information about additional configuration options, see [Specific-configuration](https://experienceleague.adobe.com//en/docs/commerce-operations/configuration-guide/message-queues/manage-message-queues#specific-configuration).
+For information about additional configuration options, see [Specific-configuration](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/message-queues/manage-message-queues#specific-configuration).
 
 ### Start message consumers
 

--- a/help/b2b/quote-templates-overview.md
+++ b/help/b2b/quote-templates-overview.md
@@ -41,9 +41,7 @@ Quote templates can be initiated by the buyer or the seller.
 
   ![Seller initiating a buyer quote from the Quotes grid in the Admin](./assets/quote-template-create-from-grid.png){width="700" zoomable="yes"}
   
-  When the seller creates the quote template, the expiration date ([!UICONTROL Valid until] date field) defaults to 180 days. If the buyer created the template, the expiration date is blank.  The buyer must set the expiration date before sending the template back to the buyer for review.
-
-  When the seller creates the quote template, the expiration date (*[!UICONTROL Valid until]* date field) defaults to 180 days. If the buyer created the template, the expiration date is blank.  The buyer must set the expiration date before sending the template back to the buyer for review.
+  When the seller creates the quote template, the expiration date (*[!UICONTROL Valid until]* date field) defaults to 180 days. If the buyer created the template, the expiration date is blank. The buyer must set the expiration date before sending the template back to the seller for review.
 
 **Step 2: Quote review and negotiation (Review)**
 


### PR DESCRIPTION
## Purpose of the pull request

This PR proposes a small grammar fix on the [Purchase order approval rules](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/purchase-orders/account-dashboard-approval-rules) page.

In step 2 of the "Approval rule setup" section, the sentence currently reads "The rule is **as enabled as the default**", which appears to use an unintended "as...as" comparison structure.

Based on the surrounding context — particularly step 2's instruction "If needed, changes the rule from Enabled to Disabled" — it seems the original intent was to clarify that **Enabled is the default state**. The suggested rewording aims to convey this more clearly.

**Before:**
> The rule is as enabled as the default, but a customer can create the rule using a disabled setting and then enable it later when they are ready to enforce it.

**After:**
> The rule is enabled by default, but a customer can create the rule using a disabled setting and then enable it later when they are ready to enforce it.

## Affected pages

<!-- It is a best practice to list the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. Including both production and staging/review URLs is most helpful. -->

-  <https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/purchase-orders/account-dashboard-approval-rules>



<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

-->
