### PR TITLE
Enhance category product rules with multiple values support

### DIFF
--- a/help/merchandising-promotions/category-product-rules.md
+++ b/help/merchandising-promotions/category-product-rules.md
@@ -87,6 +87,10 @@ Category product rules can speed up the process of assigning specific products t
     - `Less than or equal to`
     - `Contains`
 
+>[!NOTE]
+>
+>The **Contains** operator now accepts multiple comma-separated values, evaluated as an OR match. A single rule row can therefore match any of several terms instead of just one.
+
 1. Enter the **[!UICONTROL Value]** that is to be matched.
 
    ![Add Condition to Category Rule](../catalog/assets/category-rule-create.png){width="500"}
@@ -128,6 +132,7 @@ Category product rules can speed up the process of assigning specific products t
 >[!NOTE]
 >
 >When setting up a category rule, the products are matched and assigned to the rule when the category is saved. If you add a product to the catalog and want to include it in the rule, you must resave each category that is set to match products by rule. This ensures that the new product is included.
+
 
 ### Menu options
 


### PR DESCRIPTION
The **Contains** operator now supports multiple comma-separated values for OR matching in category rules. Updated notes on product matching in category rules.

## Purpose of this pull request

This pull request (PR) is to update a note on product matching in category rules related to "Contains" operator changes for https://jira.corp.adobe.com/browse/ACP2E-5182

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Additional information

### Links to the affected code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.

`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released product. Any content related to future releases should be merged to the corresponding `develop` branch.

See Contribution guidelines (https://github.com/AdobeDocs/commerce-admin.en/blob/main/contributing.md) for more information.
-->

### What's New highlights

<!--  _OPTIONAL - REMOVE THIS SECTION IF NOT USED._

If this pull request introduces changes that should be highlighted in the What's New section (https://experienceleague.adobe.com/en/docs/commerce-admin/user-guides/home#whats-new), see _What's New highlights_ in the Contribution guidelines (https://github.com/AdobeDocs/commerce-admin.en/blob/main/contributing.md#whats-new-highlights).
-->
